### PR TITLE
NetworkTraffic: Resolve status bar indicators tints

### DIFF
--- a/sdk/src/java/org/lineageos/internal/statusbar/NetworkTraffic.java
+++ b/sdk/src/java/org/lineageos/internal/statusbar/NetworkTraffic.java
@@ -16,7 +16,6 @@
 
 package org.lineageos.internal.statusbar;
 
-import android.animation.ArgbEvaluator;
 import android.content.BroadcastReceiver;
 import android.content.ContentResolver;
 import android.content.Context;
@@ -110,8 +109,7 @@ public class NetworkTraffic extends TextView {
     private LineageStatusBarItem.DarkReceiver mDarkReceiver =
             new LineageStatusBarItem.DarkReceiver() {
         public void onDarkChanged(Rect area, float darkIntensity, int tint) {
-            mIconTint = (int) ArgbEvaluator.getInstance().evaluate(darkIntensity,
-                    mLightModeFillColor, mDarkModeFillColor);
+            mIconTint = tint;
             setTextColor(mIconTint);
             updateTrafficDrawableColor();
         }
@@ -365,7 +363,7 @@ public class NetworkTraffic extends TextView {
 
     private void updateTrafficDrawableColor() {
         if (mDrawable != null) {
-            mDrawable.setColorFilter(mIconTint, PorterDuff.Mode.SRC_ATOP);
+            mDrawable.setColorFilter(mIconTint, PorterDuff.Mode.MULTIPLY);
         }
     }
 }


### PR DESCRIPTION
 * Apply the color tint with PorterDuff.Mode.MULTIPLY
    as the original color is white, with transparencies

 * Use the DarkReceiver tint's value as icons tint

 * Results: Before and after: https://ibb.co/k15ony

 * Test: Bright wallpaper with status bar contrasts:
    https://ibb.co/dxupSy

Change-Id: I4f31cf5a9a3db4018543603a891fa7967ccbb4a3